### PR TITLE
added back button controllability to step wizard

### DIFF
--- a/lib/react-step-wizard.jsx
+++ b/lib/react-step-wizard.jsx
@@ -62,7 +62,6 @@ var StepWizard = React.createClass({
   },
 
   navigateBack: function(event) {
-    console.log(event);
     this.setState(event.state);
   },
 


### PR DESCRIPTION
Known issues:

1. Visiting a web page from step wizard and coming back resets to first slide (unsure if intended behavior)
2. Advancing at least one slide, visiting a new page, hitting back to go back to step wizard, there's an extra "back" step that you have to do to go back further (the page before step wizard).