### PR TITLE
Blocked improper behavior on navigating back to an element

### DIFF
--- a/lib/react-step-wizard.jsx
+++ b/lib/react-step-wizard.jsx
@@ -62,6 +62,10 @@ var StepWizard = React.createClass({
   },
 
   navigateBack: function(event) {
+    if(this.state.currentStepIndex === event.state.currentStepIndex) {
+      return;
+    }
+    
     this.moveToPage(event.state.currentStepIndex);
   },
 


### PR DESCRIPTION
Pressing the previous button (in Chrome) would cause the onError event to get fired when it shouldn't. This fixes that (in addition to fixing refreshing the page casting onError).